### PR TITLE
Fix Cleave not supporting input type number

### DIFF
--- a/components/PaymentJourneySelection/index.tsx
+++ b/components/PaymentJourneySelection/index.tsx
@@ -120,7 +120,6 @@ export const PaymentJourneySelection: React.FC<PaymentJourneySelectionProps> = (
                   placeholder="0.00"
                   prefix="£"
                   autoFocus={true}
-                  type="number"
                   name="paymentAmount"
                   cleaveOptions={{
                     numeral: true,


### PR DESCRIPTION
Cleave.js doesn't support input type "number" and was logging warnings.