### PR TITLE
Temporary message for April DD rejections

### DIFF
--- a/pages/no-debt/index.tsx
+++ b/pages/no-debt/index.tsx
@@ -9,9 +9,11 @@ const NoDebt = () => (
     <div className={styles.container}>
       <div className={styles.card}>
         <AwardImage />
-        <h2>Good news!</h2>
         <p>
           You don't currently have any outstanding debt on your account to pay.
+        </p>
+        <p>
+          However, if your April Direct Debit payment was rejected, <strong>your overdue balance may take up to 24 hours to show on your account, so please check again tomorrow</strong>.
         </p>
         <p>
           Remember, you can keep up to date with your monthly bills via the{" "}


### PR DESCRIPTION
Same as last month, DD rejections won't show until next morning, so informing customers that they may need to visit next day to be able to pay